### PR TITLE
(maint) Fixed rendering of code block and image

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ iex (new-object System.Net.WebClient).DownloadString('https://raw.githubusercont
 
     <img src="https://github.com/PrateekKumarSingh/PSConsoleGraph/blob/master/img/AudioPeakLevels.gif" width="850" height="500" />
     
-  3. Visualizing Azure Monitor Metrics like CPU %age on a Virtual machine in #PowerShell
-
+3. Visualizing Azure Monitor Metrics like CPU %age on a Virtual machine in #PowerShell
 
     ```PowerShell
     $ResourceID = '/subscriptions/<subscription>/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/SimpleWinVM'
@@ -89,7 +88,6 @@ iex (new-object System.Net.WebClient).DownloadString('https://raw.githubusercont
 
     Import-Module Graphical
     Show-Graph -Datapoints $Datpoints -GraphTitle 'CPU (% age)'
-    
     ```
  
- ![](https://github.com/PrateekKumarSingh/Graphical/blob/master/img/AzureMonitor.png)
+    ![](https://github.com/PrateekKumarSingh/Graphical/blob/master/img/AzureMonitor.png)


### PR DESCRIPTION
These were slightly out of line in the raw markdown, meaning that the 
rendered HTML didn't look quite right.